### PR TITLE
Login route

### DIFF
--- a/src/Page/App.elm
+++ b/src/Page/App.elm
@@ -64,13 +64,16 @@ body model =
                 div [] [ text "Not found" ]
 
             Just (Route.Meeting meetingId) ->
-                issueContainer model
+                page model
 
             Just Route.Admin ->
                 Page.Admin.view model
 
             Just Route.Config ->
                 div [] [ text "config" ]
+
+            Just Route.Login ->
+                Page.Portal.view model.client model.username
 
             Just Route.Landing ->
                 div []
@@ -107,49 +110,54 @@ view model =
             , style "grid-template-columns" "1fr min(80%, 1200px) 1fr"
             ]
             [ banner isAdmin model.client
-            , case model.websocketConnection of
-                Connected ->
-                    case model.client of
-                        Just _ ->
-                            body model
-
-                        Nothing ->
-                            Page.Portal.view model.username
-
-                Reconnect _ ->
-                    Page.Loading.view
-
-                Connecting ->
-                    case model.client of
-                        Just _ ->
-                            Page.Loading.view
-
-                        Nothing ->
-                            Page.Portal.view model.username
-
-                NotConnectedYet ->
-                    case model.client of
-                        Just _ ->
-                            Page.Loading.view
-
-                        Nothing ->
-                            Page.Portal.view model.username
-
-                Disconnected ->
-                    Page.Error.view Nothing
-
-                Errored error ->
-                    Page.Error.view (Just error)
-
-                Disconnecting ->
-                    Page.Loading.view
-
-            -- we should technically show an error here
-            -- Page.Loading.view
-            , footer model.websocketConnection model.client
+            , body model
             ]
         ]
     }
+
+
+page : Model -> Html Msg
+page model =
+    case model.websocketConnection of
+        Connected ->
+            case model.client of
+                Just _ ->
+                    issueContainer model
+
+                Nothing ->
+                    -- Page.Portal.view model.username
+                    -- send to login
+                    div [] [ a [ Route.href Route.Login ] [ text "Go to login" ]]
+                    -- and send back ?
+
+        Reconnect _ ->
+            Page.Loading.view
+
+        Connecting ->
+            case model.client of
+                Just _ ->
+                    Page.Loading.view
+
+                Nothing ->
+                    Page.Portal.view model.client model.username
+
+        NotConnectedYet ->
+            case model.client of
+                Just _ ->
+                    Page.Loading.view
+
+                Nothing ->
+                    Page.Portal.view model.client model.username
+
+        Disconnected ->
+            Page.Error.view Nothing
+
+        Errored error ->
+            Page.Error.view (Just error)
+
+        Disconnecting ->
+            Page.Loading.view
+
 
 
 banner : Bool -> Maybe Client -> Html Msg

--- a/src/Page/App.elm
+++ b/src/Page/App.elm
@@ -25,7 +25,7 @@ menuitems isAdmin client =
         items =
             [ Link { icon = "🔧", route = Route.Config, show = True }
             , Link { icon = "👨\u{200D}🚒", route = Route.Admin, show = isAdmin }
-            , Button { icon = "🚨", cmd = SendWebsocketConnect, show = client /= Nothing }
+            , Button { icon = "🚨", cmd = SendWebsocketDisconnect, show = client /= Nothing }
             ]
     in
     div [ style "display" "inline-block" ]

--- a/src/Page/App.elm
+++ b/src/Page/App.elm
@@ -127,8 +127,8 @@ page model =
                 Nothing ->
                     -- Page.Portal.view model.username
                     -- send to login
-                    div [] [ a [ Route.href Route.Login ] [ text "Go to login" ]]
                     -- and send back ?
+                    div [] [ a [ Route.href Route.Login ] [ text "Go to login" ] ]
 
         Reconnect _ ->
             Page.Loading.view
@@ -157,7 +157,6 @@ page model =
 
         Disconnecting ->
             Page.Loading.view
-
 
 
 banner : Bool -> Maybe Client -> Html Msg

--- a/src/Page/Portal.elm
+++ b/src/Page/Portal.elm
@@ -1,23 +1,43 @@
 module Page.Portal exposing (view)
 
-import Html exposing (Html, button, div, h2, input, label, text)
-import Html.Attributes exposing (for, style, value)
+import Html exposing (Html, a, button, div, h2, input, label, text)
+import Html.Attributes exposing (for, href, style, value)
 import Html.Events exposing (onClick, onInput)
-import Model exposing (Msg(..))
+import Model exposing (Client, Msg(..))
+import Route exposing (Route(..))
 
 
-view : String -> Html Msg
-view username =
-    div [ style "grid-column" "2" ]
-        [ h2 [] [ text "Portal" ]
-        , div []
-            [ label [ for "username" ] [ text "Username: " ]
-            , input [ style "height" "16px", onInput SetUsername, value username ] []
-            , button [ onClick (SendLogin username) ] [ text "📞" ]
-            ]
-        , div []
-            [ label [ for "sessionid" ] [ text "SessionID: " ]
-            , input [ style "height" "16px", onInput SetUsername, value username ] []
-            , button [ onClick (Model.SendWebsocketReconnect username) ] [ text "☎️" ]
-            ]
-        ]
+view : Maybe Client -> String -> Html Msg
+view client username =
+    case client of
+        Just c ->
+            let
+                initialText =
+                    "You are already logged in"
+                loggedInText =
+                    case c.username of
+                        Just connectedUser ->
+                            initialText ++ " as " ++ connectedUser
+                        Nothing ->
+                            initialText
+            in
+            div []
+                [ div [] [ text loggedInText ]
+                -- go back ? go to stored state ?
+                , div [] [ a [ Route.href Landing ] [ text "Go to landing page" ] ]
+                ]
+
+        Nothing ->
+            div [ style "grid-column" "2" ]
+                [ h2 [] [ text "Portal" ]
+                , div []
+                    [ label [ for "username" ] [ text "Username: " ]
+                    , input [ style "height" "16px", onInput SetUsername, value username ] []
+                    , button [ onClick (SendLogin username) ] [ text "📞" ]
+                    ]
+                , div []
+                    [ label [ for "sessionid" ] [ text "SessionID: " ]
+                    , input [ style "height" "16px", onInput SetUsername, value username ] []
+                    , button [ onClick (Model.SendWebsocketReconnect username) ] [ text "☎️" ]
+                    ]
+                ]

--- a/src/Page/Portal.elm
+++ b/src/Page/Portal.elm
@@ -14,15 +14,18 @@ view client username =
             let
                 initialText =
                     "You are already logged in"
+
                 loggedInText =
                     case c.username of
                         Just connectedUser ->
                             initialText ++ " as " ++ connectedUser
+
                         Nothing ->
                             initialText
             in
             div []
                 [ div [] [ text loggedInText ]
+
                 -- go back ? go to stored state ?
                 , div [] [ a [ Route.href Landing ] [ text "Go to landing page" ] ]
                 ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -10,6 +10,7 @@ import Url.Parser as Parser exposing ((</>), Parser, oneOf, s, string)
 type Route
     = Landing
     | Meeting String
+    | Login
     | Admin
     | Config
 
@@ -21,6 +22,7 @@ parser =
         , Parser.map Meeting (s "meeting" </> string)
         , Parser.map Admin (s "admin")
         , Parser.map Config (s "config")
+        , Parser.map Login (s "login")
         ]
 
 
@@ -58,3 +60,6 @@ routeToPieces route =
 
         Config ->
             [ "config" ]
+
+        Login ->
+            [ "login" ]


### PR DESCRIPTION
Add a new /login route, and ask users to go there to login when required. In the future this should probably just happen as an automated redirect, where we also keep track of the path they came from, so we can redirect them back afterwards (such as `?redirect_to=/meeting/1` or store it in sessionstorage)